### PR TITLE
Changed matching logic for filenames to consider apostrophes as modified filenames

### DIFF
--- a/src/auto_xdcc.py
+++ b/src/auto_xdcc.py
@@ -57,7 +57,9 @@ hexchat.command("set dcc_remove " + config['clear'])
 
 logging.basicConfig(
     filename=addons_path('axdcc.log'),
-    level=logging.INFO
+    level=logging.INFO,
+    format='[%(asctime)s] %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
 )
 
 packlist_manager = PacklistManager()

--- a/src/auto_xdcc/packlist_manager.py
+++ b/src/auto_xdcc/packlist_manager.py
@@ -4,7 +4,9 @@ from typing import Callable
 
 import auto_xdcc.printer as printer
 import auto_xdcc.config as gconfig
+from auto_xdcc.util import is_modified_filename
 from auto_xdcc.packlist import Packlist, create_packlist
+
 
 class PacklistManager:
     def __init__(self):
@@ -47,7 +49,15 @@ class PacklistManager:
         return True
 
     def get_packlist_by(self, filename: str):
-        return self.queued_downloads.get(filename)
+        if filename in self.queued_downloads:
+            return self.queued_downloads.get(filename)
+
+
+        for download in self.queued_downloads.keys():
+            if is_modified_filename(download, filename):
+                return self.queued_downloads.get(download)
+
+        return None
 
     def register_timers(self, packlist: Packlist):
         packlist.register_refresh_timer(self.refresh_timer_callback)

--- a/src/auto_xdcc/util.py
+++ b/src/auto_xdcc/util.py
@@ -1,0 +1,28 @@
+def levenshtein(s1, s2):
+    """
+    Calculates edit distance between two strings using Levenshtein algorithm
+    https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Levenshtein_distance#Python
+    """
+    if len(s1) < len(s2):
+        return levenshtein(s2, s1)
+
+    # len(s1) >= len(s2)
+    if len(s2) == 0:
+        return len(s1)
+
+    previous_row = range(len(s2) + 1)
+    for i, c1 in enumerate(s1):
+        current_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            insertions = previous_row[j + 1] + 1 # j+1 instead of j since previous_row and current_row are one character longer
+            deletions = current_row[j] + 1       # than s2
+            substitutions = previous_row[j] + (c1 != c2)
+            current_row.append(min(insertions, deletions, substitutions))
+        previous_row = current_row
+
+    return previous_row[-1]
+
+def is_modified_filename(original_filename, modified_filename):
+    # Count ' characters in original filename
+    character_count = original_filename.count("'")
+    return levenshtein(original_filename, modified_filename) == character_count


### PR DESCRIPTION
Resolves issue #32

Decided to go with counting apostrophes in the original filename and matching the edit (Levenshtein) distance of both filenames with the count.